### PR TITLE
Update GitVersion configuration

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -6,7 +6,7 @@ branches:
     mode: ContinuousDelivery
     tag: ''
     increment: Patch
-    prevent-increment-of-merged-branch-version: true
+    prevent-increment-of-merged-branch-version: false
     track-merge-target: false
     source-branches:
         - develop


### PR DESCRIPTION
Changed the 'prevent-increment-of-merged-branch-version' setting in the GitVersion.yml configuration file. Previously, it was set to true, now it is set to false, allowing the version number to increment when a branch gets merged.