### PR TITLE
Remove assembly info update from GitVersionSettings

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -45,7 +45,6 @@ Task("Build")
     .Does(() => {
     
      var version = GitVersion(new GitVersionSettings {
-            UpdateAssemblyInfo = true
         });
      var buildSettings = new DotNetBuildSettings {
                         Configuration = configuration,
@@ -116,7 +115,7 @@ Task("Pack")
  .Does(() => {
  
    var version = GitVersion(new GitVersionSettings {
-             UpdateAssemblyInfo = true
+         
          });
    var settings = new DotNetPackSettings
     {


### PR DESCRIPTION
The UpdateAssemblyInfo option was removed from the GitVersionSettings in build.cake. This change will prevent GitVersion from automatically updating the assembly information during the versioning process.